### PR TITLE
 modified get_pulses to reduce errors

### DIFF
--- a/adafruit_dht.py
+++ b/adafruit_dht.py
@@ -139,7 +139,7 @@ class DHTBase:
             data returned from the device (try again)
         """
         delay_between_readings = 0.5
-        if self._dht11 :
+        if self._dht11:
             delay_between_readings = 1.0
         if time.monotonic()-self._last_called > delay_between_readings:
             self._last_called = time.monotonic()

--- a/adafruit_dht.py
+++ b/adafruit_dht.py
@@ -139,7 +139,7 @@ class DHTBase:
             data returned from the device (try again)
         """
         delay_between_readings = 0.5
-        if(self._dht11):
+        if self._dht11 :
             delay_between_readings = 1.0
         if time.monotonic()-self._last_called > delay_between_readings:
             self._last_called = time.monotonic()

--- a/adafruit_dht.py
+++ b/adafruit_dht.py
@@ -117,12 +117,9 @@ class DHTBase:
             # time out after 1/4 second
             tmono = time.monotonic()
             while True:
-                #if len(pulse_in) >= 82:
-                #    break
                 if time.monotonic()-tmono > 0.25: # time out after 1/4 seconds
                     break
 
-            #print(len(pulse_in))
             pulse_in.pause()
             while pulse_in:
                 pulses.append(pulse_in.popleft())
@@ -145,14 +142,11 @@ class DHTBase:
             self._last_called = time.monotonic()
 
             pulses = self._get_pulses()
-            #print(pulses)
-            #print(len(pulses))
 
             if len(pulses) >= 80:
                 buf = array.array('B')
                 for byte_start in range(0, 80, 16):
                     buf.append(self._pulses_to_binary(pulses, byte_start, byte_start+16))
-                #print(buf)
 
                 # humidity is 2 bytes
                 if self._dht11:
@@ -160,7 +154,7 @@ class DHTBase:
                 else:
                     self._humidity = ((buf[0]<<8) | buf[1]) / 10
 
-                # tempature is 2 bytes
+                # temperature is 2 bytes
                 if self._dht11:
                     self._temperature = buf[2]
                 else:
@@ -174,17 +168,11 @@ class DHTBase:
                 # checksum is the last byte
                 if chk_sum & 0xff != buf[4]:
                     # check sum failed to validate
-                    #print(pulses)
                     raise RuntimeError("Checksum did not validate. Try again.")
-                    #print("checksum did not match. Temp: {} Humidity: {} Checksum:{}"
-                    #.format(self._temperature,self._humidity,bites[4]))
 
-                # checksum matches
-                #print("Temp: {} C Humidity: {}% ".format(self._temperature, self._humidity))
 
             else:
                 raise RuntimeError("A full buffer was not returned.  Try again.")
-                #print("did not get a full return.  number returned was: {}".format(len(r)))
 
     @property
     def temperature(self):


### PR DESCRIPTION
There were often errors associated with prematurely cutting off the pulse train. Rather than depend on the exact number of incoming pulses, which varies depending on the timing of the start up, what for a timeout interval than always use the last 81 pulses received. This reduces the number of errors , especially on the faster M4 boards.

Also added a test to see if this was a dht11 and increased the delay between reads to 1 second as in the data sheet. dht22 uses .5 seconds