### PR TITLE
 fix DHT22 handling of negative temperatures

### DIFF
--- a/adafruit_dht.py
+++ b/adafruit_dht.py
@@ -160,12 +160,12 @@ class DHTBase:
                     self._temperature = buf[2]
                 else:
                     # temperature is 2 bytes
-                    # MSB ist sign, bits 0-14 are magnitude)
-                    self._temperature = (((buf[2] & 0x7f)<<8) | buf[3]) / 10
+                    # MSB is sign, bits 0-14 are magnitude)
+                    raw_temperature = (((buf[2] & 0x7f)<<8) | buf[3]) / 10
                     # set sign
                     if buf[2] & 0x80:
-                        self._temperature = -self._temperature
-
+                        raw_temperature = -raw_temperature
+                    self._temperature = raw_temperature
                 # calc checksum
                 chk_sum = 0
                 for b in buf[0:4]:
@@ -175,7 +175,6 @@ class DHTBase:
                 if chk_sum & 0xff != buf[4]:
                     # check sum failed to validate
                     raise RuntimeError("Checksum did not validate. Try again.")
-
 
             else:
                 raise RuntimeError("A full buffer was not returned.  Try again.")


### PR DESCRIPTION
modified driver to correctly handle sign bit for the DHT22.

tested in freezer - dht_simpletest converts to F so the transition was failing at 32 F. see issue #9 

```
 Temp: 33.8 F Humidity: 18.6% 
Temp: 33.6 F Humidity: 18.8% 
Temp: 33.3 F Humidity: 18.9% 
Temp: 33.1 F Humidity: 19.0% 
Temp: 32.9 F Humidity: 19.2% 
Temp: 32.5 F Humidity: 19.3% 
Temp: 32.4 F Humidity: 19.4% 
Temp: 32.0 F Humidity: 19.5% 
Temp: 31.8 F Humidity: 19.7% 
Temp: 31.6 F Humidity: 19.8% 
Temp: 31.5 F Humidity: 20.0% 
```

Note - tested DHT11 in the freezer, but it never reported any value < 1 C  - according to the data sheet, its range is 0- 50 C so there is no need for a sign bit.