### PR TITLE
Update README Travis Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,8 @@ Introduction
     :target: https://discord.gg/nBQh6qu
     :alt: Discord
 
-.. image:: https://travis-ci.org/adafruit/Adafruit_CircuitPython_DHT.svg?branch=master
-    :target: https://travis-ci.org/adafruit/Adafruit_CircuitPython_DHT
+.. image:: https://travis-ci.com/adafruit/Adafruit_CircuitPython_DHT.svg?branch=master
+    :target: https://travis-ci.com/adafruit/Adafruit_CircuitPython_DHT
     :alt: Build Status
 
 CircuitPython support for the DHT11 and DHT22 temperature and humidity devices.


### PR DESCRIPTION
Change 'travis-ci.org' to 'travis-ci.com'.