### PR TITLE
Immediately pause pulse_in after initialization

### DIFF
--- a/adafruit_dht.py
+++ b/adafruit_dht.py
@@ -67,6 +67,7 @@ class DHTBase:
         # and we're better off having a running process
         if _USE_PULSEIO:
             self.pulse_in = PulseIn(self._pin, 81, True)
+            self.pulse_in.pause()
 
     def _pulses_to_binary(self, pulses, start, stop):
         """Takes pulses, a list of transition times, and converts
@@ -114,7 +115,6 @@ class DHTBase:
             # specific length of time.  Then the device sends back a
             # series HIGH and LOW signals.  The length the HIGH signals
             # represents the device values.
-            self.pulse_in.pause()
             self.pulse_in.clear()
             self.pulse_in.resume(self._trig_wait)
 


### PR DESCRIPTION
Right now, pulse_in is active until the first reading and only paused after that. Let's immediately pause it to free up the CPU.

This problem was reported by @lane-maxwell at https://github.com/adafruit/Adafruit_Blinka/issues/210#issuecomment-669623485.

This is only mildly tested right now, so please do not merge immediately.