### PR TITLE
Change in the Bitbang Trigger calculation

### DIFF
--- a/adafruit_dht.py
+++ b/adafruit_dht.py
@@ -138,7 +138,8 @@ class DHTBase:
             dhtpin.value = True
             time.sleep(0.1)
             dhtpin.value = False
-            time.sleep(self._trig_wait // 1000000)  # Using the time to pull-down the line according to DHT Model
+            # Using the time to pull-down the line according to DHT Model
+            time.sleep(self._trig_wait // 1000000)
             timestamp = time.monotonic()  # take timestamp
             dhtval = True  # start with dht pin true because its pulled up
             dhtpin.direction = Direction.INPUT

--- a/adafruit_dht.py
+++ b/adafruit_dht.py
@@ -138,7 +138,7 @@ class DHTBase:
             dhtpin.value = True
             time.sleep(0.1)
             dhtpin.value = False
-            time.sleep(0.001)
+            time.sleep(self._trig_wait // 1000000)  # Using the time to pull-down the line according to DHT Model
             timestamp = time.monotonic()  # take timestamp
             dhtval = True  # start with dht pin true because its pulled up
             dhtpin.direction = Direction.INPUT


### PR DESCRIPTION
I have modified the trigger calculation. According to the Intenet there is a difference in the trigger time for the DHT11 and DHT22.  This is take into account in the library in the Child classes with the parameter 
```
class DHT11(DHTBase):
    """Support for DHT11 device.
    :param ~board.Pin pin: digital pin used for communication
    """
    def __init__(self, pin, use_pulseio=_USE_PULSEIO):
        super().__init__(True, pin, 18000, use_pulseio)

class DHT22(DHTBase):
    """Support for DHT22 device.

    :param ~board.Pin pin: digital pin used for communication
    """
    def __init__(self, pin, use_pulseio=_USE_PULSEIO):
        super().__init__(False, pin, 1000, use_pulseio)
```
However, this is not calculated for the Bitbang portion, and the time used is the time normally used for the DHT22 sensor.

Calculation when pulling the line down to start the lecture will be calculated according to the `self._trig_wait `parameter that depends on the sensor used
```
            dhtpin.direction = Direction.OUTPUT
            dhtpin.value = True
            time.sleep(0.1)
            dhtpin.value = False
            time.sleep(self._trig_wait // 1000000)  
```

Old C library different time, maybe that is why for a lot of people this works better. (if interested see this https://github.com/jposada202020/DHT_Investigation)