### PR TITLE
Correction of the integer in the new time sleep logic

### DIFF
--- a/adafruit_dht.py
+++ b/adafruit_dht.py
@@ -139,7 +139,7 @@ class DHTBase:
             time.sleep(0.1)
             dhtpin.value = False
             # Using the time to pull-down the line according to DHT Model
-            time.sleep(self._trig_wait // 1000000)
+            time.sleep(self._trig_wait / 1000000)
             timestamp = time.monotonic()  # take timestamp
             dhtval = True  # start with dht pin true because its pulled up
             dhtpin.direction = Direction.INPUT


### PR DESCRIPTION
To change the division in the new logic of the sensor.
As currently the time waiting will get a 0 (zero) because it uses python // division,  
The intend is to get 0.001 secs for DHT22 and 0.018 secs for DHT11 as the pulsein logic.
The change will get a float instead of an int getting the desired value