### PR TITLE
Add type hints

### DIFF
--- a/adafruit_dht.py
+++ b/adafruit_dht.py
@@ -83,7 +83,7 @@ class DHTBase:
             print("De-initializing self.pulse_in")
             self.pulse_in.deinit()
 
-    def _pulses_to_binary(self, pulses: array.array[int], start: int, stop: int) -> int:
+    def _pulses_to_binary(self, pulses: array.array, start: int, stop: int) -> int:
         """Takes pulses, a list of transition times, and converts
         them to a 1's or 0's.  The pulses array contains the transition times.
         pulses starts with a low transition time followed by a high transistion time.
@@ -140,7 +140,7 @@ class DHTBase:
                 pulses.append(self.pulse_in.popleft())
         return pulses
 
-    def _get_pulses_bitbang(self) -> array.array[int]:
+    def _get_pulses_bitbang(self) -> array.array:
         """_get_pulses implements the communication protcol for
         DHT11 and DHT22 type devices.  It sends a start signal
         of a specific length and listens and measures the

--- a/adafruit_dht.py
+++ b/adafruit_dht.py
@@ -65,9 +65,9 @@ class DHTBase:
         self._dht11 = dht11
         self._pin = pin
         self._trig_wait = trig_wait
-        self._last_called: float = 0
-        self._humidity: Union[int, float, None] = None
-        self._temperature: Union[int, float, None] = None
+        self._last_called = 0
+        self._humidity = None
+        self._temperature = None
         self._use_pulseio = use_pulseio
         if "Linux" not in uname() and not self._use_pulseio:
             raise Exception("Bitbanging is not supported when using CircuitPython.")
@@ -203,8 +203,8 @@ class DHTBase:
         ):
             self._last_called = time.monotonic()
 
-            new_temperature: Union[int, float] = 0
-            new_humidity: Union[int, float] = 0
+            new_temperature = 0
+            new_humidity = 0
 
             if self._use_pulseio:
                 pulses = self._get_pulses_pulseio()

--- a/adafruit_dht.py
+++ b/adafruit_dht.py
@@ -112,7 +112,7 @@ class DHTBase:
 
         return binary
 
-    def _get_pulses_pulseio(self) -> array.array[int]:
+    def _get_pulses_pulseio(self) -> array.array:
         """_get_pulses implements the communication protocol for
         DHT11 and DHT22 type devices.  It sends a start signal
         of a specific length and listens and measures the

--- a/adafruit_dht.py
+++ b/adafruit_dht.py
@@ -30,7 +30,6 @@ import array
 import time
 from os import uname
 from digitalio import DigitalInOut, Pull, Direction
-from microcontroller import Pin
 
 _USE_PULSEIO = False
 try:
@@ -40,6 +39,12 @@ try:
 except (ImportError, NotImplementedError):
     pass  # This is OK, we'll try to bitbang it!
 
+try:
+    # Used only for typing
+    from typing import Union
+    from microcontroller import Pin
+except ImportError:
+    pass
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DHT.git"
@@ -61,8 +66,8 @@ class DHTBase:
         self._pin = pin
         self._trig_wait = trig_wait
         self._last_called: float = 0
-        self._humidity: int | float | None = None
-        self._temperature: int | float | None = None
+        self._humidity: Union[int, float, None] = None
+        self._temperature: Union[int, float, None] = None
         self._use_pulseio = use_pulseio
         if "Linux" not in uname() and not self._use_pulseio:
             raise Exception("Bitbanging is not supported when using CircuitPython.")
@@ -198,8 +203,8 @@ class DHTBase:
         ):
             self._last_called = time.monotonic()
 
-            new_temperature: int | float = 0
-            new_humidity: int | float = 0
+            new_temperature: Union[int, float] = 0
+            new_humidity: Union[int, float] = 0
 
             if self._use_pulseio:
                 pulses = self._get_pulses_pulseio()
@@ -251,7 +256,7 @@ class DHTBase:
             self._humidity = new_humidity
 
     @property
-    def temperature(self) -> int | float | None:
+    def temperature(self) -> Union[int, float, None]:
         """temperature current reading.  It makes sure a reading is available
 
         Raises RuntimeError exception for checksum failure and for insufficient
@@ -261,7 +266,7 @@ class DHTBase:
         return self._temperature
 
     @property
-    def humidity(self) -> int | float | None:
+    def humidity(self) -> Union[int, float, None]:
         """humidity current reading. It makes sure a reading is available
 
         Raises RuntimeError exception for checksum failure and for insufficient


### PR DESCRIPTION
Hiya! I've added type hints for this (fixes #74 ).

These changes clear all of the errors returned from `mypy adafruit_dht.py --disallow-untyped-defs` except for one: 

```
adafruit_dht.py:149: error: Too many arguments for "__exit__" of "DigitalInOut"
```

I'd fix that one up as well, but I'm not actually sure what is causing it.

Thanks!