### PR TITLE
Read decimal value also for dht11

### DIFF
--- a/adafruit_dht.py
+++ b/adafruit_dht.py
@@ -235,8 +235,8 @@ class DHTBase:
             if self._dht11:
                 # humidity is 1 byte
                 new_humidity = buf[0]
-                # temperature is 1 byte
-                new_temperature = buf[2]
+                # temperature is 1 byte for integral and 1 byte for 1st decimal place
+                new_temperature = buf[2] + (buf[3] & 0x0F) / 10
             else:
                 # humidity is 2 bytes
                 new_humidity = ((buf[0] << 8) | buf[1]) / 10


### PR DESCRIPTION
@ladyada 

Resolves: #98 

Looking at the datasheet does seem to confirm the 4th byte holding data for the decimal value by my understanding. I also referenced the Arduino driver and found comparable step in that code here: https://github.com/adafruit/DHT-sensor-library/blob/master/DHT.cpp#L95 and borrowed from it's syntax some.

I didn''t think the float cast mentioned in the issue code is necessary because the division will make it into a float.