### PR TITLE
Raspberry Pi 3 B+ GPIO pin import fix

### DIFF
--- a/adafruit_dht.py
+++ b/adafruit_dht.py
@@ -46,7 +46,10 @@ try:
 
     from microcontroller import Pin
 except ImportError:
-    pass
+    try:
+        from adafruit_blinka.microcontroller.generic_linux.rpi_gpio_pin import Pin
+    except ImportError:
+        pass
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DHT.git"


### PR DESCRIPTION
On raspberry Pi 3b+ it would fail to import Pin from microcontroller and would try and use Jetson.GPIO library.

Now on failure to import Pin from microcontroller it has a try statement which imports Pin from Adafruit-Blinka, if not successful it passes.
